### PR TITLE
fix bug

### DIFF
--- a/include/worker_thread.h
+++ b/include/worker_thread.h
@@ -28,7 +28,7 @@ namespace pink {
 template <typename Conn>
 class WorkerThread : public Thread {
  public:
-  explicit WorkerThread(int cron_interval);
+  explicit WorkerThread(int cron_interval = 0);
   virtual ~WorkerThread();
 
   /*
@@ -75,7 +75,7 @@ class WorkerThread : public Thread {
 };  // class WorkerThread
 
 template <typename Conn>
-WorkerThread<Conn>::WorkerThread(int cron_interval = 0) :
+WorkerThread<Conn>::WorkerThread(int cron_interval) :
   cron_interval_(cron_interval) {
   /*
    * install the protobuf handler here


### PR DESCRIPTION
When I compile this project:
`./include/worker_thread.h:78:55: error: redeclaration of ‘pink::WorkerThread<Conn>::WorkerThread(int)’ may not have default arguments [-fpermissive]
 WorkerThread<Conn>::WorkerThread(int cron_interval = 0) :
`
so need to put the default argument on the declaration, not the definition.