### PR TITLE
fix array crosses

### DIFF
--- a/src/holy_thread.cc
+++ b/src/holy_thread.cc
@@ -53,9 +53,8 @@ void HolyThread::HandleConnEvent(PinkFiredEvent *pfe) {
       return;
     }
   }
-
+  in_conn = iter->second;
   if (pfe->mask & EPOLLIN) {
-    in_conn = iter->second;
     ReadStatus getRes = in_conn->GetRequest();
     struct timeval now;
     gettimeofday(&now, NULL);
@@ -70,7 +69,6 @@ void HolyThread::HandleConnEvent(PinkFiredEvent *pfe) {
     }
   }
   if (pfe->mask & EPOLLOUT) {
-    in_conn = iter->second;
     WriteStatus write_status = in_conn->SendReply();
     if (write_status == kWriteAll) {
       in_conn->set_is_reply(false);

--- a/src/redis_cli.cc
+++ b/src/redis_cli.cc
@@ -182,7 +182,7 @@ static char *seekNewline(char *s, size_t len) {
    * might not have a trailing NULL character. */
   while (pos < _len) {
     while (pos < _len && s[pos] != '\r') pos++;
-    if (s[pos] != '\r') {
+    if (s[pos] != '\r' || pos >= _len) {
       /* Not found. */
       return NULL;
     } else {

--- a/src/worker_thread.cc
+++ b/src/worker_thread.cc
@@ -93,9 +93,9 @@ void *WorkerThread::ThreadMain() {
           pink_epoll_->PinkDelEvent(pfe->fd);
           continue;
         }
-
+        
+        in_conn = iter->second;
         if (pfe->mask & EPOLLIN) {
-          in_conn = iter->second;
           ReadStatus getRes = in_conn->GetRequest();
           in_conn->set_last_interaction(now);
           if (getRes != kReadAll && getRes != kReadHalf) {
@@ -108,7 +108,6 @@ void *WorkerThread::ThreadMain() {
           }
         }
         if (pfe->mask & EPOLLOUT) {
-          in_conn = iter->second;
           WriteStatus write_status = in_conn->SendReply();
           if (write_status == kWriteAll) {
             in_conn->set_is_reply(false);


### PR DESCRIPTION
while (pos < _len && s[pos] != '\r') pos++;
it maybe pos >= _len, but dont compare s[pos] != '\r' when skip while.
so it maybe pos == _len and s[pos] == '\r', but here should return
for example:
current buf rbuf="12345678\r\nabcd"
valid buf rbuf="12345678\r"
"\nabcd" is old buf, is invalid
it match \r\n, but there is \r only, in seekNewline() function